### PR TITLE
Periodically logging dialer stats

### DIFF
--- a/balancer_test.go
+++ b/balancer_test.go
@@ -47,6 +47,12 @@ func TestSingleDialer(t *testing.T) {
 		doTestConn(t, conn)
 	}
 
+	if assert.Len(t, b.dialers.dialers, 1) {
+		assert.EqualValues(t, 1, b.dialers.dialers[0].stats.attempts)
+		assert.EqualValues(t, 1, b.dialers.dialers[0].stats.successes)
+		assert.EqualValues(t, 0, b.dialers.dialers[0].stats.failures)
+	}
+
 	// Test close balancer
 	b.Close()
 	time.Sleep(250 * time.Millisecond)

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,20 @@
+package balancer
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+// stats are basic dialing stats
+type stats struct {
+	attempts  int64
+	successes int64
+	failures  int64
+}
+
+func (s *stats) String(d *dialer) string {
+	successes := atomic.LoadInt64(&s.successes)
+	failures := atomic.LoadInt64(&s.failures)
+	attempts := atomic.LoadInt64(&s.attempts)
+	return fmt.Sprintf("Dialer Stats for %v\t\tSuccess: %7d / %7d\t\tFailure: %7d / %7d\t\tDial Time: %v", d.Label, successes, attempts, failures, attempts, d.emaDialTime.Get())
+}


### PR DESCRIPTION
This will help us understand what servers a client is using and how they're performing by looking at a user's log file.
